### PR TITLE
Update soaper-dl.sh

### DIFF
--- a/soaper-dl.sh
+++ b/soaper-dl.sh
@@ -203,8 +203,9 @@ download_media() {
     p="$(sed 's/.*e_//;s/.html//' <<< "$1")"
     d="$("$_CURL" -sS "${_HOST}/home/index/${u}" \
         -H "referer: https://${_HOST}${1}" \
-        --data-raw "pass=${p}&param=ddd&extra=&e2=0")"
+        --data-raw "pass=${p}")"
     el="$($_JQ -r '.val' <<< "$d")"
+    el="${_HOST}${el}"
     [[ "$el" != *".m3u8" ]] && el="$($_JQ -r '.val_bak' <<< "$d")"
     if [[ "$($_JQ '.subs | length' <<< "$d")" -gt "0" ]]; then
         sl="$($_JQ -r '.subs[]| select(.name | ascii_downcase | contains ("'"$_SUBTITLE_LANG"'")) | .path' <<< "$d" | head -1)"

--- a/soaper-dl.sh
+++ b/soaper-dl.sh
@@ -204,8 +204,7 @@ download_media() {
     d="$("$_CURL" -sS "${_HOST}/home/index/${u}" \
         -H "referer: https://${_HOST}${1}" \
         --data-raw "pass=${p}")"
-    el="$($_JQ -r '.val' <<< "$d")"
-    el="${_HOST}${el}"
+    el="${_HOST}$($_JQ -r '.val' <<< "$d")"
     [[ "$el" != *".m3u8" ]] && el="$($_JQ -r '.val_bak' <<< "$d")"
     if [[ "$($_JQ '.subs | length' <<< "$d")" -gt "0" ]]; then
         sl="$($_JQ -r '.subs[]| select(.name | ascii_downcase | contains ("'"$_SUBTITLE_LANG"'")) | .path' <<< "$d" | head -1)"


### PR DESCRIPTION
Removes excess parameters to --data-raw which causes $_HOST to be removed, then readding it by overwriting $el to add $_HOST to its overall string.

Testing seems to only have this happen with movies and not shows, will PR again if I find evidence otherwise.

EDIT: I know this is a very sloppy and overall lazy way to fix it, but I'd rather someone not have to do it themselves. Maybe you could switch it to a cleaner approach.