### PR TITLE
Added Functionality [-m] to only download media and not subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ```
 Usage:
-  ./soaper-dl.sh [-n <name>] [-p <path>] [-e <num1,num2,num3-num4...>] [-l] [-s] [-d]
+  ./soaper-dl.sh [-n <name>] [-p <path>] [-e <num1,num2,num3-num4...>] [-l] [-s] [-m] [-d]
 
 Options:
   -n <name>               TV series or Movie name

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Options:
                           episode range using "-"
   -l                      optional, list video or subtitle link without downloading
   -s                      optional, download subtitle only
+  -m                      optional, download media only
   -d                      enable debug mode
   -h | --help             display this help message
 ```
@@ -125,6 +126,12 @@ $ mpv "$(./soaper-dl.sh -p /tv_YxAgjOVGEL.html -e 1.1 -l)"
 
 ```
 ./soaper-dl.sh -n 'game of thrones' -s
+```
+
+- Download media only
+
+```
+./soaper-dl.sh -n 'game of thrones' -m
 ```
 
 - Customize subtitle language

--- a/soaper-dl.sh
+++ b/soaper-dl.sh
@@ -218,9 +218,7 @@ download_media() {
         sl="${_HOST}$sl"
     fi
 
-    # if LIST_LINK_ONLY IS LENGTH 0
     if [[ -z ${_LIST_LINK_ONLY:-} ]]; then
-        # if sl length is not 0
         if [[ -n "${sl:-}" ]]; then
             if [[ -z ${_DOWNLOAD_MEDIA_ONLY:-} ]]; then
               print_info "Downloading subtitle $2..."


### PR DESCRIPTION
This should only download the media and skip downloading the subtitle with -m passed on the command line.