### PR TITLE
feat: add soaper_download_path env variable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ $ mpv "$(./soaper-dl.sh -p /tv_YxAgjOVGEL.html -e 1.1 -l)"
 SOAPER_SUBTITLE_LANG=fr ./soaper-dl.sh -n 'game of thrones'
 ```
 
+- Customize download folder for the videos
+
+```bash
+SOAPER_DOWNLOAD_PATH=~/Downloads/Videos ./soaper-dl.sh -n 'game of thrones'
+```
+
 ## Disclaimer
 
 The purpose of this script is to download TV series episodes and movies in order to watch them later in case when Internet is not available. Please do NOT copy or distribute downloaded materials to any third party. Watch them and delete them afterwards. Please use this script at your own responsibility.

--- a/soaper-dl.sh
+++ b/soaper-dl.sh
@@ -36,7 +36,8 @@ set_var() {
     _SEARCH_URL="$_HOST/search/keyword/"
 
     _SCRIPT_PATH=$(dirname "$(realpath "$0")")
-    _SEARCH_LIST_FILE="${_SCRIPT_PATH}/search.list"
+    _DOWNLOAD_PATH="${SOAPER_DOWNLOAD_PATH:-$_SCRIPT_PATH}"
+    _SEARCH_LIST_FILE="$(mktemp -t soaper-dl-search-list.XXXXXX)"
     _SOURCE_FILE=".source.html"
     _EPISODE_LINK_LIST=".episode.link"
     _EPISODE_TITLE_LIST=".episode.title"
@@ -104,7 +105,7 @@ sed_remove_space() {
 
 download_media_html() {
     # $1: media link
-    "$_CURL" -sS "${_HOST}${1}" > "$_SCRIPT_PATH/$_MEDIA_NAME/$_MEDIA_HTML"
+    "$_CURL" -sS "${_HOST}${1}" > "$_DOWNLOAD_PATH/$_MEDIA_NAME/$_MEDIA_HTML"
 }
 
 get_media_name() {
@@ -139,13 +140,13 @@ is_movie() {
 
 download_source() {
     local d a
-    mkdir -p "$_SCRIPT_PATH/$_MEDIA_NAME"
+    mkdir -p "$_DOWNLOAD_PATH/$_MEDIA_NAME"
     d="$("$_CURL" -sS "${_HOST}${_MEDIA_PATH}")"
     a="$($_PUP ".alert-info-ex" <<< "$d")"
     if is_movie "$_MEDIA_PATH"; then
         download_media "$_MEDIA_PATH" "$_MEDIA_NAME"
     else
-        echo "$a" > "$_SCRIPT_PATH/$_MEDIA_NAME/$_SOURCE_FILE"
+        echo "$a" > "$_DOWNLOAD_PATH/$_MEDIA_NAME/$_SOURCE_FILE"
     fi
 }
 
@@ -188,7 +189,7 @@ download_episodes() {
 download_episode() {
     # $1: episode number
     local l
-    l=$(grep "\[$1\] " "$_SCRIPT_PATH/$_MEDIA_NAME/$_EPISODE_LINK_LIST" \
+    l=$(grep "\[$1\] " "$_DOWNLOAD_PATH/$_MEDIA_NAME/$_EPISODE_LINK_LIST" \
         | awk -F '] ' '{print $2}')
     [[ "$l" != *"/"* ]] && print_error "Wrong download link or episode not found!"
     download_media "$l" "$1"
@@ -215,13 +216,14 @@ download_media() {
     fi
 
     if [[ -z ${_LIST_LINK_ONLY:-} ]]; then
+        print_info "Downloading to $_DOWNLOAD_PATH/${_MEDIA_NAME}/..."
         if [[ -n "${sl:-}" && "$sl" != "$_HOST" ]]; then
             print_info "Downloading subtitle $2..."
-            "$_CURL" "${sl}" > "$_SCRIPT_PATH/${_MEDIA_NAME}/${2}_${_SUBTITLE_LANG}.srt"
+            "$_CURL" "${sl}" > "$_DOWNLOAD_PATH/${_MEDIA_NAME}/${2}_${_SUBTITLE_LANG}.srt"
         fi
         if [[ -z ${_DOWNLOAD_SUBTITLE_ONLY:-} ]]; then
             print_info "Downloading video $2..."
-            "$_FFMPEG" -i "$el" -c copy -v error -y "$_SCRIPT_PATH/${_MEDIA_NAME}/${2}.mp4"
+            "$_FFMPEG" -i "$el" -c copy -v error -y "$_DOWNLOAD_PATH/${_MEDIA_NAME}/${2}.mp4"
         fi
     else
         if [[ -z ${_DOWNLOAD_SUBTITLE_ONLY:-} ]]; then
@@ -236,9 +238,9 @@ download_media() {
 
 create_episode_list() {
     local slen sf t l sn et el
-    sf="$_SCRIPT_PATH/$_MEDIA_NAME/$_SOURCE_FILE"
-    el="$_SCRIPT_PATH/$_MEDIA_NAME/$_EPISODE_LINK_LIST"
-    et="$_SCRIPT_PATH/$_MEDIA_NAME/$_EPISODE_TITLE_LIST"
+    sf="$_DOWNLOAD_PATH/$_MEDIA_NAME/$_SOURCE_FILE"
+    el="$_DOWNLOAD_PATH/$_MEDIA_NAME/$_EPISODE_LINK_LIST"
+    et="$_DOWNLOAD_PATH/$_MEDIA_NAME/$_EPISODE_TITLE_LIST"
     slen="$(grep 'alert alert-info-ex' -c "$sf")"
     true > "$et"
     true > "$el"
@@ -258,7 +260,7 @@ create_episode_list() {
 }
 
 select_episodes_to_download() {
-    cat "$_SCRIPT_PATH/$_MEDIA_NAME/$_EPISODE_TITLE_LIST" >&2
+    cat "$_DOWNLOAD_PATH/$_MEDIA_NAME/$_EPISODE_TITLE_LIST" >&2
     echo -n "Which episode(s) to download: " >&2
     read -r s
     echo "$s"


### PR DESCRIPTION
So I stripped the .sh extension and put this in my path so I could run it from anywhere, and had a hard time finding where did the download go. So I made some modifications to get a better user experience which I think would be useful to others also.

This pr:

1. adds option to use `SOAPER_DOWLOAD_PATH` env variable to specify where the download goes. Defaults to `_SCRIPT_PATH`, like it is now.

2. adds one `print_info` line at the start of the download to info user where the download is going.

3. adds an example in the readme to let users know how to use it.

4. use mktemp for the `_SEARCH_LIST_FILE`, instead of spamming users folder with temp files.

I have ran this few times without problems, but propably needs some more testing to see if anything breaks.

Running shellcheck, there was only one unrelated error, I'll leave that to someone else.
```sh
In soaper-dl.sh line 51:
        case $opt in
        ^-- SC2213 (warning): getopts specified -x, but it's not handled by this 'case'.
```

Cheers, let me know if you want some changes to this, or if it is ok as is.

